### PR TITLE
Separate `wsgiref` into a python2-specific requirements file.

### DIFF
--- a/interview_requirements.py2.txt
+++ b/interview_requirements.py2.txt
@@ -1,0 +1,2 @@
+-r interview_requirements.txt
+wsgiref==0.1.2

--- a/interview_requirements.txt
+++ b/interview_requirements.txt
@@ -9,6 +9,5 @@ pytz==2013.9
 MarkupSafe==0.23
 six==1.5.2
 Jinja2==2.7.2
-wsgiref==0.1.2
 Pygments==1.6
 requests==2.8.1


### PR DESCRIPTION
Installing interview_requirements.txt on python3 fails because the `wsgiref` package on pypi is python2-only. Since `wsgiref` is included in the standard library in python3, there's no need to require it when using python3.

I created a python2 requirements file that extends the base required packages with `wsgiref`. If you're not interested in supporting both py2 and py3, feel free to ignore this PR.
