### PR TITLE
Adds python2.7 version to virtualenv creation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ First, clone this repository to your computer via the links on the right (creati
 
 When you have `virtualenv` installed, create a new Python environment and activate it by running:
 ```bash
-virtualenv interview_env
+virtualenv interview_env --python=python2.7
 source interview_env/bin/activate
 ```
 


### PR DESCRIPTION
 ### Reviewers
r? @shale-stripe 

 ### Summary
This updates the virtualenv command to specify `python2.7` in README, which is needed for developers who are running `virtualenv` in python3.

