### PR TITLE
Bump requests to 2.21.0 (latest) to fix CVE

### DIFF
--- a/interview_requirements.txt
+++ b/interview_requirements.txt
@@ -11,4 +11,4 @@ six==1.6.0
 Jinja2==2.7.2
 wsgiref==0.1.2
 Pygments==1.6
-requests==2.8.1
+requests==2.21.0


### PR DESCRIPTION
r? @shale-stripe (you touched it last? sorry)

requests 2.8.1 has a CVE (https://nvd.nist.gov/vuln/detail/CVE-2018-18074). I can't imagine it's exploitable, but you never know.

2.21.0 is latest master - http://docs.python-requests.org/en/master/