### PR TITLE
A comment for fish shell setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ and install some requirements that will be useful in your interviews.
 > use [virtualenv] to create the virtual environment.
 
 Create a new Python 3 environment called `interview_env` and _activate_ it
-(Mac or Linux):
+(`bash` compatible shells on Mac or Linux):
 
 ```bash
 $ python3 -m venv ./interview_env
-$ source ./interview_env/bin/activate
+$ source ./interview_env/bin/activate # or source ./interview_env/bin/activate.fish if you're using fish shell
 ```
 
 On Windows (assuming `cmd.exe`):


### PR DESCRIPTION
`virtualenv` ships with support for `fish` shell and provides `activate.fish` file to activate environment from `fish` shell. Added a comment to use activation file specific to `fish`. Finding it is just a matter of peeking into `bin` directory, and an astute `fish` user may as well find a workaround, but a quick comment saves time.