### PR TITLE
Use package-versions compatible with Python 3.12 and 3.6

### DIFF
--- a/interview_requirements.txt
+++ b/interview_requirements.txt
@@ -1,2 +1,3 @@
-six==1.12.0
-requests==2.22.0
+six==1.16.0
+requests==2.27.1
+urllib3<2.0


### PR DESCRIPTION
The old version of `requests` wasn't fully compatible with Python 3.12. These requirements were checked with Python 3.12 and 3.6, and should be compatible with 3.7–3.11.