### PR TITLE
Remove irrelevant comment about Python 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ Finally, in that activated virtual environment, verify that your environment sup
 TLS 1.2 supported; no action required.
 ```
 
-(Use `python verify_tls.py` for Python 2.7.)
-
 If you see a response that begins with `Error`, follow the instructions it provides.
 [MacOS SSL debugging] may be helpful.
 


### PR DESCRIPTION
It's the same command as above, so this comment doesn't add anything except confusion.